### PR TITLE
feat(decorations): implement folder decorations

### DIFF
--- a/src/base/decorationUtils.ts
+++ b/src/base/decorationUtils.ts
@@ -1,0 +1,63 @@
+import { FileDecoration } from "./decorationService";
+
+export function computeBubbleUpFolderDecorations(
+  decorations: Map<string, FileDecoration>,
+  rootPath: string
+): void {
+  const folderColorCounts = new Map<string, Map<string, number>>();
+  const root = rootPath.replace(/\/$/, '');
+
+  for (const [uri, decoration] of decorations.entries()) {
+    if (!decoration.color) {
+      continue;
+    }
+
+    let currentPath = uri.replace(/\/$/, '');
+
+    while (currentPath.length > root.length && currentPath.startsWith(root)) {
+      const lastSlashIdx = currentPath.lastIndexOf('/');
+      if (lastSlashIdx <= 0) {
+        break;
+      }
+
+      const parentPath = currentPath.substring(0, lastSlashIdx);
+      if (parentPath.length <= root.length) {
+        break;
+      }
+
+      if (!folderColorCounts.has(parentPath)) {
+        folderColorCounts.set(parentPath, new Map<string, number>());
+      }
+
+      const colorMap = folderColorCounts.get(parentPath)!;
+      colorMap.set(decoration.color, (colorMap.get(decoration.color) || 0) + 1);
+
+      currentPath = parentPath;
+    }
+  }
+
+  for (const [folderPath, colorMap] of folderColorCounts.entries()) {
+    let winningColor: string | undefined;
+    let maxCount: number = 0;
+
+    for (const [color, count] of colorMap.entries()) {
+      if (count > maxCount) {
+        maxCount = count;
+        winningColor = color;
+      }
+    }
+
+    if (winningColor) {
+      const decoration: FileDecoration = {
+        color: winningColor
+      };
+
+      if (!decorations.has(folderPath)) {
+        decorations.set(folderPath, decoration);
+      }
+      if (!decorations.has(folderPath + '/')) {
+        decorations.set(folderPath + '/', decoration);
+      }
+    }
+  }
+}

--- a/src/base/fileTreeDecoration.ts
+++ b/src/base/fileTreeDecoration.ts
@@ -215,7 +215,8 @@ function renderDecoration(
           width: '7px',
           height: '7px',
           borderRadius: '50%',
-          backgroundColor: decoration.color
+          backgroundColor: decoration.color,
+          opacity: '0.5'
         }
       }));
     } else if (isFileWithBadge) {

--- a/src/base/fileTreeDecoration.ts
+++ b/src/base/fileTreeDecoration.ts
@@ -157,6 +157,7 @@ class FileTreeElementManager {
 
 function applyDecoration(element: HTMLElement): void {
   const url = element.dataset.url;
+  const type = element.dataset.type;
 
   if (!url) {
     return;
@@ -171,20 +172,28 @@ function applyDecoration(element: HTMLElement): void {
   }
 
   if (decoration.propagate !== false) {
-    renderDecoration(element, decoration);
+    renderDecoration(element, decoration, type);
   }
 }
 
-function renderDecoration(element: HTMLElement, decoration: FileDecoration): void {
+function renderDecoration(
+  element: HTMLElement,
+  decoration: FileDecoration,
+  type: 'file' | 'dir' | string | undefined
+): void {
   const text = element.querySelector('.text') as HTMLElement;
   let badge = element.querySelector('.badge') as HTMLElement | null;
 
-  if (decoration.badge) {
+  const isDirWithColor = type === 'dir' && !!decoration.color;
+  const isFileWithBadge = type === 'file' && !!decoration.badge;
+
+  if (!isDirWithColor && !isFileWithBadge) {
+    badge?.remove();
+  } else {
     if (!badge) {
       badge = tag('span', {
         className: 'badge',
         style: {
-          fontSize: '1em',
           height: '30px',
           minWidth: '30px',
           display: 'flex',
@@ -192,21 +201,33 @@ function renderDecoration(element: HTMLElement, decoration: FileDecoration): voi
           alignItems: 'center'
         }
       });
-      if (text.nextSibling) {
-        element.insertBefore(badge, text.nextSibling);
-      } else {
-        element.appendChild(badge);
-      }
+      text.nextSibling
+        ? element.insertBefore(badge, text.nextSibling)
+        : element.appendChild(badge);
     }
-    badge.textContent = decoration.badge;
-  } else if (badge) {
-    badge.remove();
-    badge = null;
+
+    badge.textContent = '';
+
+    if (isDirWithColor) {
+      badge.appendChild(tag('span', {
+        className: 'custom-dot',
+        style: {
+          width: '7px',
+          height: '7px',
+          borderRadius: '50%',
+          backgroundColor: decoration.color
+        }
+      }));
+    } else if (isFileWithBadge) {
+      badge.textContent = decoration.badge!;
+      badge.style.fontSize = '1em';
+    }
   }
 
   const color = decoration.color || 'var(--primary-text-color)';
   text.style.color = color;
-  if (badge) {
+
+  if (badge && isFileWithBadge) {
     badge.style.color = color;
   }
 }

--- a/src/git/decorationProvider.ts
+++ b/src/git/decorationProvider.ts
@@ -5,6 +5,7 @@
 
 import { config } from "../base/config";
 import { DecorationProvider, decorationService, FileDecoration } from "../base/decorationService";
+import { computeBubbleUpFolderDecorations } from "../base/decorationUtils";
 import { debounce } from "../base/decorators";
 import { Disposable, IDisposable } from "../base/disposable";
 import { Emitter, Event } from "../base/event";
@@ -121,6 +122,8 @@ class GitDecorationProvider implements DecorationProvider {
     this.collectDecorationData(this.repository.workingTreeGroup, newDecorations);
     this.collectDecorationData(this.repository.mergeGroup, newDecorations);
     this.collectSubmoduleDecorationData(newDecorations);
+
+    computeBubbleUpFolderDecorations(newDecorations, this.repository.root);
 
     const uris = new Set([...this.decorations.keys()].concat([...newDecorations.keys()]));
     this.decorations = newDecorations;


### PR DESCRIPTION
- Extract folder decoration calculation into a reusable utility function.
- Add 'most-wins' color priority logic for parent directories based on modified files.
- Introduce a smaller emphasized dot badge for folders.